### PR TITLE
Enabling suggestions for @-mentions in groups component

### DIFF
--- a/groups/single/forum/topic.php
+++ b/groups/single/forum/topic.php
@@ -138,7 +138,7 @@
 
 					<h4><?php _e( 'Add a reply:', 'buddypress' ); ?></h4>
 
-					<textarea name="reply_text" id="reply_text"></textarea>
+					<textarea name="reply_text" id="reply_text" class="bp-suggestions"></textarea>
 
 					<div class="submit">
 						<input type="submit" name="submit_reply" id="submit" value="<?php esc_attr_e( 'Post Reply', 'buddypress' ); ?>" />


### PR DESCRIPTION
https://buddypress.trac.wordpress.org/ticket/5934 : To enable suggestions specifically for group forums - once the required script gets loaded for groups component -, .bp-suggestions needs to be added.
